### PR TITLE
Change console.warn to console.log for better output clarity

### DIFF
--- a/src/core/printer.ts
+++ b/src/core/printer.ts
@@ -59,7 +59,7 @@ export class Printer {
           if (Array.isArray(message)) {
             this.array(message);
           } else {
-            console.warn("Expected an array for type 'array'");
+            console.log("Expected an array for type 'array'");
           }
           break;
         case "error":
@@ -181,7 +181,7 @@ export class Printer {
    */
   static warning(message: string) {
     if (this.shouldPrint()) {
-      console.warn(formatMessage("warning", message));
+      console.log(formatMessage("warning", message));
     }
   }
 
@@ -192,10 +192,10 @@ export class Printer {
    */
   static error(message: string, error?: unknown) {
     if (this.shouldPrint()) {
-      console.error(formatMessage("error", message));
+      console.log(formatMessage("error", message));
       if (error) {
         const errMsg = error instanceof Error ? error.stack || error.message : String(error);
-        console.error(formatMessage("error", errMsg));
+        console.log(formatMessage("error", errMsg));
       }
     }
   }


### PR DESCRIPTION
Update logging methods in the Printer class to use console.log instead of console.warn for improved output consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized how log messages are displayed so that warnings and errors now appear with a uniform style, resulting in a more consistent log output for users reviewing console messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->